### PR TITLE
Allow documentation to be specified in the param definition

### DIFF
--- a/templates/lib/tasks/doc_generator/template.erb
+++ b/templates/lib/tasks/doc_generator/template.erb
@@ -72,7 +72,7 @@
                     <% api.send(rule_meth).each do |rule| %> 
                       <li>
                         <span class='label notice'><%= rule.name %></span> of type <span class='label success'><%= rule.options[:type] || 'String' %></span>
-                        <% if desc = api.doc.params_doc[rule.name.to_sym] %>
+                        <% if desc = (api.doc.params_doc[rule.name.to_sym] || rule.options[:doc]) %>
                            <%= desc %>&nbsp;
                         <% end %>
                         <% if options = rule.options[:options] %>


### PR DESCRIPTION
In my service params definition, I want to specify documentation like I do for responses. This patch allows for:

service.params do |p|
    p.string :email , :doc => "Email address of the recipient."
end
