### PR TITLE
make app.rb optional

### DIFF
--- a/lib/wd_sinatra/app_loader.rb
+++ b/lib/wd_sinatra/app_loader.rb
@@ -88,7 +88,10 @@ module WDSinatra
     end
 
     def load_app_file
-      require File.join(root_path, 'lib', 'app')
+      app_file = File.join(root_path, 'lib', 'app')
+      if File.exist?(app_file)
+        require app_file
+      end
     end
 
     def load_models


### PR DESCRIPTION
Newly generated projects bomb out with a load error because app.rb doesn't exist. This checks for existence before requiring.
