### PR TITLE
Moving the API divs down 60px so the names aren't blocked.

### DIFF
--- a/templates/lib/tasks/doc_generator/template.erb
+++ b/templates/lib/tasks/doc_generator/template.erb
@@ -17,6 +17,10 @@
       body {
         padding-top: 60px;
       }
+      div.api {
+        padding-top: 60px;
+        margin-top: -60px;
+      }
     </style>
 
     <!-- Le fav and touch icons -->
@@ -57,7 +61,7 @@
         </div>
 
         <% WSList.all.each do |api| %>
-          <div class="" id="<%= "raw-#{api.verb}-#{api.url}" %>">
+          <div class="api" id="<%= "raw-#{api.verb}-#{api.url}" %>">
             <div>
               <h2><%= api.verb.upcase %> <%= '[SSL]' if api.ssl %> /<%= api.url %></h2>
               <% if api.auth_required %>


### PR DESCRIPTION
The service names are obscured by the topbar when using the left-nav links. This +60 -60 hack makes the browser scroll a bit further so the proper stuff visible.
