### PR TITLE
Fix Gemfile platform typo

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
 # Specify your gem's dependencies in wd-sinatra.gemspec
-gem 'backports', '2.3.0', :platform => 'ruby_18'
-gem 'json', :platform => 'ruby_18'
+gem 'backports', '2.3.0', :platforms => 'ruby_18'
+gem 'json', :platforms => 'ruby_18'
 gemspec


### PR DESCRIPTION
The Gemfile docs say the option is `:platforms` not `platform`. I'm running 2.0.0 and `bundle` gave me some error about the `backports` gem.
