### PR TITLE
Set content type based on accept header

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
 # Specify your gem's dependencies in wd-sinatra.gemspec
-gem 'backports', '2.3.0', :platforms => 'ruby_18'
+gem 'backports', '>= 2.3.0', :platforms => 'ruby_18'
 gem 'json', :platforms => 'ruby_18'
 gemspec

--- a/templates/Gemfile
+++ b/templates/Gemfile
@@ -1,17 +1,17 @@
-source "http://rubygems.org"
+source "https://rubygems.org"
 
 gem "wd_sinatra"
 gem "activesupport"
-# gem 'wd_newrelic_rpm', :require => 'newrelic_rpm'
+# gem "wd_newrelic_rpm", :require => "newrelic_rpm"
 
-gem 'backports', '2.3.0', :platform => 'ruby_18'
-gem 'json', :platform => 'ruby_18'
+gem "backports", ">= 2.3.0", :platforms => "ruby_18"
+gem "json", :platforms => "ruby_18"
 
 group :development, :test do
-  gem "rack-test", "0.6.1"
+  gem "rack-test", ">= 0.6.1"
   # gem "foreman"
   # gem "puma"
-  gem "minitest"
+  gem "minitest", "~> 4.7.4"
   # gem "guard-puma"
   # gem "guard-minitest"
   gem "rake"

--- a/templates/api/hello_world.rb
+++ b/templates/api/hello_world.rb
@@ -1,5 +1,5 @@
 describe_service "/hello_world" do |service|
-  service.formats   :json
+  service.formats   :json, :xml
   service.http_verb :get
   service.disable_auth # on by default
 
@@ -23,7 +23,13 @@ describe_service "/hello_world" do |service|
 
   # ACTION/IMPLEMENTATION
   service.implementation do
-    {:message => "Hello #{params[:name]}", :at => Time.now}.to_json
+    data = {:message => "Hello #{params[:name]}", :at => Time.now}
+    case params[:format]
+    when :json
+      data.to_json
+    when :xml
+      # data.to_xml # serialize to xml
+    end
   end
 
 end

--- a/templates/api/hello_world.rb
+++ b/templates/api/hello_world.rb
@@ -24,7 +24,7 @@ describe_service "/hello_world" do |service|
   # ACTION/IMPLEMENTATION
   service.implementation do
     data = {:message => "Hello #{params[:name]}", :at => Time.now}
-    case params[:format]
+    case env["wd.format"]
     when :json
       data.to_json
     when :xml

--- a/templates/lib/hooks.rb
+++ b/templates/lib/hooks.rb
@@ -52,12 +52,18 @@ module WDSinatraHooks
   # Implementation example
   def pre_dispatch_hook
     # content negotiation
-    require "rack/accept"
     accept = env["rack-accept.request"]
-    service_media_types = SUPPORTED_MEDIA_TYPES.select {|k,v| service.formats.include?(v)}
-    env["wd.media_type"] = accept.media_type.best_of(service_media_types.keys)
-    halt 406 unless env["wd.media_type"]
-    env["wd.format"] =  SUPPORTED_MEDIA_TYPES[env["wd.media_type"]]
+    if accept
+      service_media_types = SUPPORTED_MEDIA_TYPES.select {|k,v| service.formats.include?(v)}
+      env["wd.media_type"] = accept.media_type.best_of(service_media_types.keys)
+      halt 406 unless env["wd.media_type"]
+      env["wd.format"] =  SUPPORTED_MEDIA_TYPES[env["wd.media_type"]]
+    else
+      env["wd.media_type"] = "*/*"
+      env["wd.format"] =  service.formats.first
+      halt 406 unless env["wd.format"] # 406 if no defined service.formats
+    end
+
     content_type env["wd.format"], charset: "utf-8"
 
     if service.extra[:mobile]

--- a/templates/lib/hooks.rb
+++ b/templates/lib/hooks.rb
@@ -55,9 +55,9 @@ module WDSinatraHooks
     require "rack/accept"
     accept = env["rack-accept.request"]
     service_media_types = SUPPORTED_MEDIA_TYPES.select {|k,v| service.formats.include?(v)}
-    media_type = accept.media_type.best_of(service_media_types.keys)
-    halt 406 unless media_type
-    env["wd.format"] =  SUPPORTED_MEDIA_TYPES[media_type]
+    env["wd.media_type"] = accept.media_type.best_of(service_media_types.keys)
+    halt 406 unless env["wd.media_type"]
+    env["wd.format"] =  SUPPORTED_MEDIA_TYPES[env["wd.media_type"]]
     content_type env["wd.format"], charset: "utf-8"
 
     if service.extra[:mobile]

--- a/templates/lib/hooks.rb
+++ b/templates/lib/hooks.rb
@@ -57,8 +57,8 @@ module WDSinatraHooks
     service_media_types = SUPPORTED_MEDIA_TYPES.select {|k,v| service.formats.include?(v)}
     media_type = accept.media_type.best_of(service_media_types.keys)
     halt 406 unless media_type
-    params[:format] =  SUPPORTED_MEDIA_TYPES[media_type]
-    content_type params[:format], charset: "utf-8"
+    env["wd.format"] =  SUPPORTED_MEDIA_TYPES[media_type]
+    content_type env["wd.format"], charset: "utf-8"
 
     if service.extra[:mobile]
       mobile_auth_check

--- a/wd-sinatra.gemspec
+++ b/wd-sinatra.gemspec
@@ -24,7 +24,5 @@ Gem::Specification.new do |gem|
   gem.add_dependency('rack-accept', ">= 0.4.5")
   gem.add_dependency('rack-test')
   gem.add_dependency('thor')
-  gem.add_dependency('minitest')
+  gem.add_dependency('minitest', "~> 4.7.4")
 end
-
-

--- a/wd-sinatra.gemspec
+++ b/wd-sinatra.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency('weasel_diesel', ">= 1.2.1")
   gem.add_dependency('rack', ">= 1.4.4")
   gem.add_dependency('rack-parser', ">= 0.2.0")
+  gem.add_dependency('rack-accept', ">= 0.4.5")
   gem.add_dependency('rack-test')
   gem.add_dependency('thor')
   gem.add_dependency('minitest')


### PR DESCRIPTION
Related to #14 and https://github.com/mattetti/Weasel-Diesel/issues/6.

Ended up setting the format in `env["wd.format"]` to match `service.formats`. The purpose of the `SUPPORTED_MEDIA_TYPES` map is so you can define custom media types like `application/vnd.example-v1+json` and map that to `:json`. I ended up storing the selected media type as `env["wd.media_type"]` so you can access it from the service implementation. 
