### PR TITLE
Use Rerun gem for auto code reloading in development/test

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,12 +38,11 @@ The app is now ready to use, to start it you can use rack:
 This will start the server on port 9292 and the default GET `/hello_world` service will be available at: `http://localhost:9292/hello_world'.
 
 Note that the code won't be reloading automatically in the server when
-you make a modification to the source code. For that, you might want to
-use Puma + [Guard](https://github.com/jc00ke/guard-puma) or another tool that allows you to do that.
-While it's a nice feature to have, a lot of developers like to do that
-differently and it seems more sensitive to let them pick the way they
-like the most.
+you make a modification to the source code. For that, we include
+[rerun](https://github.com/alexch/rerun), which is only enabled in the
+development and test environments. Use it like this:
 
+    $ bundle exec rerun -- rackup
 
 ### Generating a new service
 

--- a/templates/Gemfile
+++ b/templates/Gemfile
@@ -12,7 +12,15 @@ group :development, :test do
   # gem "foreman"
   # gem "puma"
   gem "minitest", "~> 4.7.4"
-  # gem "guard-puma"
   # gem "guard-minitest"
   gem "rake"
+
+  gem "rerun"
+  # You can optionally comment out libraries not matching your OS platform
+  # Even if you don't, only the gem supported by your OS will be used by rerun
+  gem "rb-fsevent", ">= 0.9.3" # Mac OS X
+  gem "rb-inotify", ">= 0.9" # Linux
+  gem "rb-kqueue", ">= 0.2" # FreeBSD, NetBSD, OpenBSD, and Darwin
+  require "rbconfig"
+  gem "wdm", ">= 0.1.0" if RbConfig::CONFIG["target_os"] =~ /mswin|mingw/i # Windows
 end


### PR DESCRIPTION
I've been using [rerun](https://github.com/alexch/rerun) in my local wd-sinatra app for auto code reloading. I know in the README, you said you wanted to leave it up to the developer to implement, but I think we should have a baked in solution so that the end user can get up and running quickly developing.

I chose rerun, because:
1. The Sinatra FAQ [recommends it](http://www.sinatrarb.com/faq.html#reloading).
2. It uses [listen](https://github.com/guard/listen) so it can support different OS platforms.
3. It should work with any ruby application server since it'll just restart the process.
4. All it requires is adding rerun and the notification gem for your platform to enable it, no other configuration.

All you do is:

```
$ bundle exec rerun -- rackup
```
