### PR TITLE
Switch to inflecto for inflections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ generated via thor now, instead of rake.
 * Update doc generation to support optional namespaces.
 * Simpler, more compact documentation template.
   Removes `WD::Response::Element#to_html` and Bootstrap dependencies.
+* Remove activesupport as a dependency, use inflecto for inflection support.
 
 ### Resolved issues
 * Fix conflict with current Sinatra's `template`.

--- a/bin/wd_sinatra
+++ b/bin/wd_sinatra
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 require "rubygems"
 require "thor/group"
-require "active_support/inflector"
+require "inflecto"
 
 class WdSinatra < Thor::Group
   include Thor::Actions
@@ -25,7 +25,7 @@ class WdSinatra < Thor::Group
 
   protected
   def name_const
-    @name_const ||= name.gsub(/\W/, '_').squeeze('_').camelize
+    @name_const ||= Inflecto.camelize(name.gsub(/\W/, '_').squeeze('_'))
   end
 end
 

--- a/lib/wd_sinatra/app_loader.rb
+++ b/lib/wd_sinatra/app_loader.rb
@@ -4,7 +4,6 @@ require 'logger'
 require 'sinatra/base'
 require 'weasel_diesel'
 require 'wd_sinatra/ws_list_ext'
-require 'active_support/inflector'
 
 module WDSinatra
   module AppLoader

--- a/templates/Gemfile
+++ b/templates/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 
 gem "wd_sinatra"
-gem "activesupport"
+gem "inflecto"
 # gem "wd_newrelic_rpm", :require => "newrelic_rpm"
 
 gem "backports", ">= 2.3.0", :platforms => "ruby_18"

--- a/templates/Thorfile
+++ b/templates/Thorfile
@@ -1,7 +1,7 @@
 # encoding: utf-8
 $:.unshift File.expand_path("../lib", __FILE__)
 require 'bundler'
-require 'active_support/inflector'
+require 'inflecto'
 require 'weasel_diesel/cli'
 
 class Default < Thor
@@ -48,7 +48,7 @@ class Default < Thor
       RUBY
     end
 
-    class_name = path_without_suffix.classify.gsub(/::/, '') # strip modules; just want a unique class name for spec
+    class_name = Inflecto.classify(path_without_suffix).gsub(/::/, '') # strip modules; just want a unique class name for spec
     create_file(File.join("test", "integration", "#{path_without_suffix}_test.rb")) do
       <<-RUBY.gsub(/^\s{6}/, '')
       require 'test_helpers'

--- a/wd-sinatra.gemspec
+++ b/wd-sinatra.gemspec
@@ -27,10 +27,5 @@ Gem::Specification.new do |gem|
   gem.add_dependency('rack-test')
   gem.add_dependency('thor')
   gem.add_dependency('minitest', "~> 4.7.4")
-
-  if RUBY_VERSION =~ /1.9.2/
-    gem.add_dependency('activesupport', "~> 3.2")
-  else
-    gem.add_dependency('activesupport') # used by the generator
-  end
+  gem.add_dependency('inflecto')
 end


### PR DESCRIPTION
We currently require `activesupport` just for it's inflection library. This PR switches to [inflecto](https://github.com/mbj/inflecto), which is an inflection gem extracted from datamapper/extlib. The benefit here is that we can drop `activesupport` as a dependency, and there's no String monkey patching involved in inflecto.
